### PR TITLE
Rails 3.1 compatible upgrades.

### DIFF
--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -2,16 +2,20 @@ require File.expand_path('authentication_header', File.dirname(__FILE__))
 
 module Rapleaf
   module Marketo
-    def self.new_client(access_key, secret_key, api_subdomain = 'na-i', api_version = '1_5', document_version = '1_4')
+    def self.new_client(config)
+      config["api_subdomain"] ||= 'na-i'
+      config["api_version"] ||= '1_5'
+      config["document_version"] ||= '1_4'
+
       client = Savon::Client.new do
-        wsdl.endpoint     = "https://#{api_subdomain}.marketo.com/soap/mktows/#{api_version}"
-        wsdl.document     = "http://app.marketo.com/soap/mktows/#{document_version}?WSDL"
+        wsdl.endpoint     = "https://#{config["api_subdomain"]}.marketo.com/soap/mktows/#{config["api_version"]}"
+        wsdl.document     = "http://app.marketo.com/soap/mktows/#{config["document_version"]}?WSDL"
         http.read_timeout = 90
         http.open_timeout = 90
         http.headers      = {"Connection" => "Keep-Alive"}
       end
 
-      Client.new(client, Rapleaf::Marketo::AuthenticationHeader.new(access_key, secret_key))
+      Client.new(client, Rapleaf::Marketo::AuthenticationHeader.new(config["access_key"], config["secret_key"]))
     end
 
     # = The client for talking to marketo

--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -6,9 +6,10 @@ module Rapleaf
       config["api_subdomain"] ||= 'na-i'
       config["api_version"] ||= '1_5'
       config["document_version"] ||= '1_4'
+      config["endpoint"] ||= "https://na-sj02.marketo.com/soap/mktows/2_0"
 
       client = Savon::Client.new do
-        wsdl.endpoint     = "https://#{config["api_subdomain"]}.marketo.com/soap/mktows/#{config["api_version"]}"
+        wsdl.endpoint     = config["endpoint"]
         wsdl.document     = "http://app.marketo.com/soap/mktows/#{config["document_version"]}?WSDL"
         http.read_timeout = 90
         http.open_timeout = 90

--- a/marketo.gemspec
+++ b/marketo.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.rdoc_options << '--title' << 'Marketo Client Gem' << '--main' << 'Rapleaf::Marketo::Client'
 
   gem.add_development_dependency('rspec', '>= 2.3.0')
-  gem.add_dependency('savon', '>= 0.8.3')
+  gem.add_dependency('savon', '~> 1')
 end


### PR DESCRIPTION
Savon gem is grossly out of date and doesn't play well with more up to date gems (curb).
- Upgrade to highest working Savon gem 1.2 (as of writing gem is at 2.0.2)
- Upgrade to the latest 2_0 marketo endpoint (hardcoded endpoint kept producing "request not recognized" errors).
- Change config inputs to hash style so you can custom-define the entire endpoint.

I don't expect you to merge this because changing the config to hash style will break the API. However, it's generally good practice so we don't have to keep remembering the order of the params.

Please feel free to cherry pick my work, and commit them yourself if you want. This pull is so other people searching for this gem and running into the same problems have some answers. 

Also please let us know if and when you plan to update compatibility with your own API (marketo). I know it's likely not your fault _personally_ but from one professional company (Gild) using your services to another profesional company (marketo) we would really appreciate some updates.
