### PR TITLE
Fix gem dependencies and add brief README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ marketo_gem
 
 More information about this gem can be found at [Rapleaf](https://www.rapleaf.com/developers/rapleaf-labs/marketo-gem-documentation/).
 
-Note that you probably need to specify your API endpoint as well as your API key and secret.
+Note that you probably need to specify your API endpoint as well as your API key and secret.  It's also possible to specify the API version you'd like to use.
 
-These are found within Marketo > Admin > Integration > SOAP API
+Your own key, secret and subdomain are found within Marketo > Admin > Integration > SOAP API.
 
 For example:
 
@@ -13,7 +13,7 @@ For example:
 
 access_key = "your_access_key"    # Marketo UI calls this User ID
 secret = "your_secret"            # Marketo UI calls this Encryption Key
-api_subdomain = "na-l"            # Look for this in what Marketo UI calls 'SOAP endpoint'
+your_subdomain = "na-l"           # Look for this in what Marketo UI calls 'SOAP endpoint'
 
-client = Rapleaf::Marketo.new_client(access_key, secret, api_subdomain = 'na-i', api_version = '1_5', document_version = '1_4')
+client = Rapleaf::Marketo.new_client(access_key, secret, api_subdomain = your_subdomain, api_version = '1_5', document_version = '1_4')
 ```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+marketo_gem
+===========
+
+More information about this gem can be found at [Rapleaf](https://www.rapleaf.com/developers/rapleaf-labs/marketo-gem-documentation/).
+
+Note that you probably need to specify your API endpoint as well as your API key and secret.
+
+These are found within Marketo > Admin > Integration > SOAP API
+
+For example:
+
+```ruby
+
+access_key = "your_access_key"    # Marketo UI calls this User ID
+secret = "your_secret"            # Marketo UI calls this Encryption Key
+api_subdomain = "na-l"            # Look for this in what Marketo UI calls 'SOAP endpoint'
+
+client = Rapleaf::Marketo.new_client(access_key, secret, api_subdomain = 'na-i', api_version = '1_5', document_version = '1_4')
+```

--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -4,7 +4,7 @@ module Rapleaf
   module Marketo
     def self.new_client(access_key, secret_key, api_subdomain = 'na-i', api_version = '1_5', document_version = '1_4')
       client = Savon::Client.new do
-        wsdl.endpoint     = "https://#{api_subdomain}.marketo.com/soap/mktows/#{api_version}"
+        wsdl.endpoint     = "https://#{api_subdomain}.mktoapi.com/soap/mktows/#{api_version}"
         wsdl.document     = "http://app.marketo.com/soap/mktows/#{document_version}?WSDL"
         http.read_timeout = 90
         http.open_timeout = 90

--- a/marketo.gemspec
+++ b/marketo.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.has_rdoc     = true
   gem.rdoc_options << '--title' << 'Marketo Client Gem' << '--main' << 'Rapleaf::Marketo::Client'
 
-  gem.add_development_dependency('rspec', '>= 2.3.0')
-  gem.add_dependency('savon', '>= 0.8.3')
+  gem.add_development_dependency('rspec', '~> 2.3.0')
+  gem.add_dependency('savon', '~> 1.2.0')
 end


### PR DESCRIPTION
With a hat tip to @gpxl whose code enabled me to get the marketo gem working again - thanks!

On trying to get this going I found it wasn't working because savon has updated. The marketo_gem code doesn't seem work with the latest version of savon.

Quick solution, as @gpxl has already found, is to replace >= 0.8.3 with ~> 1.2.0 in the gemspec.

Another thing that slowed me down was finding some documentation. So I thought I'd add a tiny README.
