### PR TITLE
gem.require_path should be a string

### DIFF
--- a/marketo.gemspec
+++ b/marketo.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.authors      = ["James O'Brien"]
   gem.homepage     = "https://www.rapleaf.com/developers/marketo"
   gem.files        = Dir['lib/**/*.rb']
-  gem.require_path = ['lib']
+  gem.require_path = 'lib'
   gem.test_files   = Dir['spec/**/*_spec.rb']
   gem.version      = "1.4.0"
   gem.has_rdoc     = true


### PR DESCRIPTION
Currently `bundle install`ing this gem results in a `TypeError` ("can't convert Array into String") under Ruby 1.9.3-p429 and Bundler 1.3.5.
