### PR TITLE
fix 'TypeError: can't convert Symbol into Integer' if multiple leads are returned in Rapleaf::Marketo::Client#get_lead

### DIFF
--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -177,7 +177,9 @@ module Rapleaf
       def get_lead(lead_key)
         begin
           response = send_request("ns1:paramsGetLead", {:lead_key => lead_key.to_hash})
-          return LeadRecord.from_hash(response[:success_get_lead][:result][:lead_record_list][:lead_record])
+          lead_record = response[:success_get_lead][:result][:lead_record_list][:lead_record]
+          lead_record = lead_record.first if lead_record.is_a?(Array)
+          return LeadRecord.from_hash(lead_record)
         rescue Exception => e
           @logger.log(e) if @logger
           return nil


### PR DESCRIPTION
Stack trace:

```
TypeError: can't convert Symbol into Integer
marketo/lead_record.rb:13 in "[]"
marketo/lead_record.rb:13 in "from_hash"
marketo/client.rb:180 in "get_lead"
marketo/client.rb:73 in "get_lead_by_email"
```
