### PR TITLE
allow fully qualified api domain in Rapleaf::Marketo.new_client

### DIFF
--- a/lib/marketo/client.rb
+++ b/lib/marketo/client.rb
@@ -2,9 +2,10 @@ require File.expand_path('authentication_header', File.dirname(__FILE__))
 
 module Rapleaf
   module Marketo
-    def self.new_client(access_key, secret_key, api_subdomain = 'na-i', api_version = '1_5', document_version = '1_4')
+    def self.new_client(access_key, secret_key, api_domain = 'na-i', api_version = '1_5', document_version = '1_4')
+      api_domain = "#{api_domain}.marketo.com" unless api_domain.include?('.')
       client = Savon::Client.new do
-        wsdl.endpoint     = "https://#{api_subdomain}.marketo.com/soap/mktows/#{api_version}"
+        wsdl.endpoint     = "https://#{api_domain}/soap/mktows/#{api_version}"
         wsdl.document     = "http://app.marketo.com/soap/mktows/#{document_version}?WSDL"
         http.read_timeout = 90
         http.open_timeout = 90

--- a/spec/marketo/client_spec.rb
+++ b/spec/marketo/client_spec.rb
@@ -3,6 +3,21 @@ require File.expand_path('../spec_helper', File.dirname(__FILE__))
 module Rapleaf
   module Marketo
 
+    describe ".new_client" do
+      it "defaults the api domain to na-i.marketo.com" do
+        client = Rapleaf::Marketo.new_client('access_key', 'secret_key')
+        client.instance_variable_get('@client').wsdl.endpoint.should =~ /na-i.marketo.com/
+      end
+      it "defaults the domain to .marketo.com given a subdomain" do
+        client = Rapleaf::Marketo.new_client('access_key', 'secret_key', 'na-j')
+        client.instance_variable_get('@client').wsdl.endpoint.should =~ /na-j.marketo.com/
+      end
+      it "allows a fully qualified domain" do
+        client = Rapleaf::Marketo.new_client('access_key', 'secret_key', '123-ABC-456.mktoapi.com')
+        client.instance_variable_get('@client').wsdl.endpoint.should =~ /123-ABC-456.mktoapi.com/
+      end
+    end
+
     describe Client do
       EMAIL   = "some@email.com"
       IDNUM   = 29


### PR DESCRIPTION
For our new account Marketo seems to be giving API domains like `123-ABC-456.mktoapi.com`.  Update the client to be backwards-compatible but allow fully qualified domains.
